### PR TITLE
Add custom HTTP header support for proxies

### DIFF
--- a/OpenCloudSDK/Connection/OCConnection.m
+++ b/OpenCloudSDK/Connection/OCConnection.m
@@ -715,6 +715,16 @@ INCLUDE_IN_CLASS_SETTINGS_SNAPSHOTS(OCConnection)
 		[request addHeaderFields:_staticHeaderFields];
 	}
 
+	// Custom HTTP header from user settings
+	NSString *customHeaderName = [[NSUserDefaults standardUserDefaults] stringForKey:@"custom-http-header-name"];
+	NSString *customHeaderValue = [[NSUserDefaults standardUserDefaults] stringForKey:@"custom-http-header-value"];
+
+	if ((customHeaderName != nil) && (customHeaderName.length > 0) &&
+	    (customHeaderValue != nil) && (customHeaderValue.length > 0))
+	{
+		[request setValue:customHeaderValue forHeaderField:customHeaderName];
+	}
+
 	return (request);
 }
 


### PR DESCRIPTION

## Description
Adds support for a user-configurable custom HTTP header that is attached to every outgoing request. The header name and value are read from NSUserDefaults in prepareRequestForScheduling:, the single chokepoint for all HTTP requests in the SDK. Leaving either field empty results in no header being added.

## Related Issue
Resolves https://github.com/orgs/opencloud-eu/discussions/2557

## Motivation and Context
Users running OpenCloud behind reverse proxies sometimes need a custom HTTP header on all requests for routing or authentication gating. The iOS app currently has no way to attach custom headers, which can prevent the app from working in these deployments.

## How Has This Been Tested?
Built and tested on iOS sim. Verified via Traefik access logs that the custom header appears on all outgoing requests. Verified that leaving the fields empty results in no change to existing behavior.

## Screenshots (if appropriate):
See companion PR in opencloud-eu/ios.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

